### PR TITLE
Raise error in transactional callbacks

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,8 @@ module ReactRailsStarterApp
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
+    config.active_record.raise_in_transactional_callbacks = true
+
     config.autoload_paths += Dir["#{config.root}/lib/**/"]
 
     config.action_dispatch.default_headers = {


### PR DESCRIPTION
From the deprecation warning we get:

DEPRECATION WARNING: Currently, Active Record suppresses errors raised within `after_rollback`/`after_commit` callbacks and only print them to the logs. In the next version, these errors will no longer be suppressed. Instead, the errors will propagate normally just like in other Active Record callbacks.

You can opt into the new behavior and remove this warning by setting:

  config.active_record.raise_in_transactional_callbacks = true