### PR TITLE
Move autoprefixer-rails into dev group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem "rails", "5.0.2"
 gem "pg"
 
 # UI
-gem "autoprefixer-rails"
 gem "non-stupid-digest-assets" # also compile assets without digest (fixes font problem)
 gem "sass-rails"
 gem "uglifier"
@@ -50,6 +49,9 @@ gem "rack-cors", require: "rack/cors"
 gem "will_paginate"
 
 group :development do
+  # UI
+  gem "autoprefixer-rails"
+
   gem "better_errors"
   gem "binding_of_caller", platforms: [:mri_21]
   gem "hub", require: nil


### PR DESCRIPTION
It isn't needed in production env. And unnecessarily requires a node environment be installed on production.