### PR TITLE
Use .start_with? instead of .include?

### DIFF
--- a/app/lib/url_helper.rb
+++ b/app/lib/url_helper.rb
@@ -6,7 +6,7 @@ class UrlHelper
 
   def self.ensure_scheme(url)
     return nil unless url.present?
-    url = "http://#{url}" unless url.include?("http")
+    url = "http://#{url}" unless url.start_with?("http")
     url
   end
 


### PR DESCRIPTION
This fixes where a url might have a path that includes http
For example
"example.com/how-to-http-all-the-things"