### PR TITLE
Update password length

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -137,7 +137,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 8..128
+  config.password_length = 14..72
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -137,7 +137,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 14..72
+  config.password_length = 14..64
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly


### PR DESCRIPTION
bcrypt truncates passwords after 64 characters. No sense in allowing
more than that length at this time.