### PR TITLE
Nginx http redirect

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -56,6 +56,12 @@ server {
 }
 
 server {
+    listen *:80;
+    server_name ${ASSETS_SUBDOMAIN}.atomicjolt.xyz;
+    return 301 https://${ASSETS_SUBDOMAIN}.atomicjolt.xyz\$request_uri;
+}
+
+server {
 
     listen *:443 ssl;
     server_name ${APP_SUBDOMAIN}.atomicjolt.xyz;
@@ -80,6 +86,12 @@ server {
 
     }
 }
+server {
+    listen *:80;
+    server_name ${APP_SUBDOMAIN}.atomicjolt.xyz;
+    return 301 https://${APP_SUBDOMAIN}.atomicjolt.xyz\$request_uri;
+}
+
 EOF
 
 #Add app subdomains
@@ -116,6 +128,13 @@ server {
 
   }
 }
+
+server {
+    listen *:80;
+    server_name ${SUBDOMAIN}.atomicjolt.xyz;
+    return 301 https://${SUBDOMAIN}.atomicjolt.xyz\$request_uri;
+}
+
 EOFSINGLE
   done
 fi

--- a/bin/setup
+++ b/bin/setup
@@ -21,10 +21,9 @@ bin/bootstrap
 # Create config file for the app / site.
 cat > "/usr/local/etc/nginx/servers/${APP_SUBDOMAIN}.conf" <<-EOF
 server {
-    listen *:443;
+    listen *:443 ssl;
     server_name ${ASSETS_SUBDOMAIN}.atomicjolt.xyz;
 
-    ssl on;
     ssl_session_cache         builtin:1000  shared:SSL:10m;
     ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers               HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
@@ -58,10 +57,9 @@ server {
 
 server {
 
-    listen *:443;
+    listen *:443 ssl;
     server_name ${APP_SUBDOMAIN}.atomicjolt.xyz;
 
-    ssl on;
     ssl_session_cache         builtin:1000  shared:SSL:10m;
     ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers               HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
@@ -94,10 +92,9 @@ then
 
 server {
 
-  listen *:443;
+  listen *:443 ssl;
   server_name ${SUBDOMAIN}.atomicjolt.xyz;
 
-  ssl on;
   ssl_session_cache         builtin:1000  shared:SSL:10m;
   ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
   ssl_ciphers               HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;

--- a/bin/setup-linux
+++ b/bin/setup-linux
@@ -23,10 +23,9 @@ echo "Run bin/bootstrap separately, not using sudo"
 # Create config file for the app / site.
 cat > "/etc/nginx/sites-available/${APP_SUBDOMAIN}.conf" <<-EOF
 server {
-    listen *:443;
+    listen *:443 ssl;
     server_name ${ASSETS_SUBDOMAIN}.atomicjolt.xyz;
 
-    ssl on;
     ssl_session_cache         builtin:1000  shared:SSL:10m;
     ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers               HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
@@ -66,10 +65,9 @@ server {
 
 server {
 
-    listen *:443;
+    listen *:443 ssl;
     server_name ${APP_SUBDOMAIN}.atomicjolt.xyz;
 
-    ssl on;
     ssl_session_cache         builtin:1000  shared:SSL:10m;
     ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers               HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
@@ -108,10 +106,9 @@ then
 
 server {
 
-  listen *:443;
+  listen *:443 ssl;
   server_name ${SUBDOMAIN}.atomicjolt.xyz;
 
-  ssl on;
   ssl_session_cache         builtin:1000  shared:SSL:10m;
   ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
   ssl_ciphers               HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;

--- a/bin/setup-linux
+++ b/bin/setup-linux
@@ -59,6 +59,12 @@ server {
 }
 
 server {
+    listen *:80;
+    server_name ${ASSETS_SUBDOMAIN}.atomicjolt.xyz;
+    return 301 https://${ASSETS_SUBDOMAIN}.atomicjolt.xyz\$request_uri;
+}
+
+server {
 
     listen *:443;
     server_name ${APP_SUBDOMAIN}.atomicjolt.xyz;
@@ -83,6 +89,12 @@ server {
       proxy_pass         http://127.0.0.1:${APP_PORT}/;
 
     }
+}
+
+server {
+    listen *:80;
+    server_name ${APP_SUBDOMAIN}.atomicjolt.xyz;
+    return 301 https://${APP_SUBDOMAIN}.atomicjolt.xyz\$request_uri;
 }
 EOF
 
@@ -120,6 +132,12 @@ server {
     proxy_pass         http://127.0.0.1:${APP_PORT}/;
 
   }
+}
+
+server {
+    listen *:80;
+    server_name ${SUBDOMAIN}.atomicjolt.xyz;
+    return 301 https://${SUBDOMAIN}.atomicjolt.xyz\$request_uri;
 }
 EOFSINGLE
   done


### PR DESCRIPTION
set up nginx to redirect http traffic to https for convenience. Also removes use of deprecated 'ssl on' directive, in favor of add 'ssl' to 'listen'.

Has not been tested on Mac yet.