### PR TITLE
puma runs on the APP_PORT specified in your .env file

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -9,7 +9,7 @@ threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests, default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port        ENV.fetch("APP_PORT") { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
so you don't have to use the -p flag if you develop multiple rails projects